### PR TITLE
Add ability to export to GLTF.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea/
 bin/
 obj/
+imgui.ini
+Preferences.json
+.vscode/

--- a/Common/GltfExport.cs
+++ b/Common/GltfExport.cs
@@ -1,0 +1,182 @@
+﻿using GaneshaDx.Resources.ContentDataTypes.Polygons;
+using System.Numerics;
+using System.Text.Json;
+using SharpGLTF.Geometry;
+using SharpGLTF.Materials;
+using SharpGLTF.Memory;
+using SharpGLTF.Schema2;
+using SharpGLTF.Geometry.VertexTypes;
+using System.IO;
+using GaneshaDx.Resources;
+using System.Collections.Generic;
+using GaneshaDx.Environment;
+using Microsoft.Xna.Framework;
+using Vector4 = System.Numerics.Vector4;
+using Vector3 = System.Numerics.Vector3;
+using Vector2 = System.Numerics.Vector2;
+using MTex2D = Microsoft.Xna.Framework.Graphics.Texture2D;
+
+namespace GaneshaDx.Common
+{
+  public static class GltfExport {
+
+		/**
+		* Exports the map model to the .gltf format.
+		*/
+		public static void Export(string filePath) {
+			var stateTexture = CurrentMapState.StateData.Texture;
+			
+			var greyPalette = new List<Color>() {
+				Utilities.GetColorFromHex("000000"),
+				Utilities.GetColorFromHex("111111"),
+				Utilities.GetColorFromHex("222222"),
+				Utilities.GetColorFromHex("333333"),
+				Utilities.GetColorFromHex("444444"),
+				Utilities.GetColorFromHex("555555"),
+				Utilities.GetColorFromHex("666666"),
+				Utilities.GetColorFromHex("777777"),
+				Utilities.GetColorFromHex("888888"),
+				Utilities.GetColorFromHex("999999"),
+				Utilities.GetColorFromHex("AAAAAA"),
+				Utilities.GetColorFromHex("BBBBBB"),
+				Utilities.GetColorFromHex("CCCCCC"),
+				Utilities.GetColorFromHex("DDDDDD"),
+				Utilities.GetColorFromHex("EEEEEE"),
+				Utilities.GetColorFromHex("FFFFFF")
+			};
+			
+			var texturedMesh = new MeshBuilder<VertexPosition, VertexTexture1>("texturedMesh");
+			var texturedPrims = new List<PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexTexture1, VertexEmpty>>();
+
+			foreach(var palette in CurrentMapState.StateData.Palettes) {
+				var textureColors = new Color[stateTexture.Width * stateTexture.Height];
+				stateTexture.GetData<Color>(textureColors);
+
+				// For the current palette, replace greyscale pixels with palette color.
+				for (int x = 0; x < textureColors.Length; x++) {
+					var pixelColor = textureColors[x];
+					if (greyPalette.Contains(pixelColor)) {
+						var index = greyPalette.IndexOf(pixelColor);
+						var paletteColor = palette.Colors[index];
+						textureColors[x] = paletteColor.ToColor();
+					}
+				}
+
+				// Convert raw Color data back to a Texture2D to be converted to PNG for embedding.
+				var texture = new MTex2D(Stage.Ganesha.GraphicsDevice, stateTexture.Width, stateTexture.Height);
+				texture.SetData<Color>(textureColors);
+				var stream = new MemoryStream();
+				texture.SaveAsPng(stream, stateTexture.Width, stateTexture.Height);
+				var textureBytes = stream.ToArray();
+
+				var material = new MaterialBuilder();
+				// @todo: Tweak the material so that it exports as close to possible as game-rendered version.
+				//material.WithMetallicRoughness(0, 0);
+				//material.WithUnlitShader(); // this looks close but material doesn't get lighting at all.
+
+				var memoryImage = new MemoryImage(textureBytes);
+
+				// @todo: Why do specular options always crash on export?
+				//material.WithSpecularGlossinessShader()
+				//	.WithDiffuse(memoryImage, new Vector4(0))
+				//	.WithSpecularGlossiness(memoryImage, new Vector3(0), 0f);
+
+				material.WithChannelImage(KnownChannel.BaseColor, memoryImage);
+				material.GetChannel(KnownChannel.BaseColor)
+                .Texture
+                .WithSampler(
+									TextureWrapMode.CLAMP_TO_EDGE, 
+									TextureWrapMode.MIRRORED_REPEAT, 
+									TextureMipMapFilter.NEAREST_MIPMAP_NEAREST, 
+									TextureInterpolationFilter.NEAREST
+								);
+
+				texturedPrims.Add(texturedMesh.UsePrimitive(material));
+			}
+
+			var blackMesh = new MeshBuilder<VertexPosition>("blackMesh");
+			var blackMat = new MaterialBuilder();
+			blackMat.WithBaseColor(new Vector4(0,0,0,1));
+			var blackPrim = blackMesh.UsePrimitive(blackMat);
+
+			foreach (Polygon polygon in CurrentMapState.StateData.PolygonCollectionBucket) {
+				if (polygon.IsQuad) {
+					var verts = polygon.Vertices;
+					var uvs = polygon.UvCoordinates;
+
+					if (polygon.IsTextured) {
+						// 0,1,3,2 is FFT vertex order, reversing here to correct facing/back-culling.
+						texturedPrims[polygon.PaletteId].AddQuadrangle(
+							(PositionToV3(verts[2].Position), UvToV2(uvs[2], polygon.TexturePage)),
+							(PositionToV3(verts[3].Position), UvToV2(uvs[3], polygon.TexturePage)),
+							(PositionToV3(verts[1].Position), UvToV2(uvs[1], polygon.TexturePage)),
+							(PositionToV3(verts[0].Position), UvToV2(uvs[0], polygon.TexturePage))
+						);
+					} else {
+						blackPrim.AddQuadrangle(
+							PositionToVPos(verts[2].Position), 
+							PositionToVPos(verts[3].Position), 
+							PositionToVPos(verts[1].Position), 
+							PositionToVPos(verts[0].Position)
+						);
+					}
+				} else {
+					var verts = polygon.Vertices;
+					var uvs = polygon.UvCoordinates;
+					if (polygon.IsTextured) {
+						// 0, 1, 2
+						texturedPrims[polygon.PaletteId].AddTriangle(
+							(PositionToV3(verts[2].Position), UvToV2(uvs[2], polygon.TexturePage)),
+							(PositionToV3(verts[1].Position), UvToV2(uvs[1], polygon.TexturePage)),
+							(PositionToV3(verts[0].Position), UvToV2(uvs[0], polygon.TexturePage))
+						);
+					} else {
+						blackPrim.AddTriangle(
+							PositionToVPos(verts[2].Position), 
+							PositionToVPos(verts[1].Position), 
+							PositionToVPos(verts[0].Position)
+						);
+					}
+				}
+			}
+
+			var scene = new SharpGLTF.Scenes.SceneBuilder();
+			scene.AddRigidMesh(texturedMesh, Matrix4x4.Identity);
+			scene.AddRigidMesh(blackMesh, Matrix4x4.Identity);
+
+			// @todo: export lights
+
+			var model = scene.ToGltf2();
+			var settings = new WriteSettings();
+			settings.ImageWriting = ResourceWriteMode.EmbeddedAsBase64;
+			settings.MergeBuffers = true;
+			var jsonWriterOptions = new JsonWriterOptions();
+			jsonWriterOptions.Indented = true;
+			settings.JsonOptions = jsonWriterOptions;
+			model.SaveGLTF(filePath, settings);
+		}
+
+		/**	
+		 * Convert XNA Vector3 to System.Numerics.Vector3.
+		 */ 
+		private static Vector3 PositionToV3 (Microsoft.Xna.Framework.Vector3 position) {
+			return new Vector3(position.X, position.Y, position.Z);
+		}
+
+		/**	
+		 * Convert XNA Vector3 to SharpGLTF VertexPosition.
+		 */ 
+		private static VertexPosition PositionToVPos (Microsoft.Xna.Framework.Vector3 position) {
+			return new VertexPosition(position.X, position.Y, position.Z);
+		}
+
+		/**
+		 * Convert XNA Vector2 to System.Numerics.Vector2 and adjust UV position based on the texture page.
+		 */
+		private static Vector2 UvToV2 (Microsoft.Xna.Framework.Vector2 uv, int texturePage) {
+			double adjustedX = uv.X / 256f;
+			double adjustedY = (uv.Y + 256 * texturePage) / 1024f;
+			return new Vector2((float) adjustedX, (float) adjustedY);
+		}
+	}
+}

--- a/Common/GltfExport.cs
+++ b/Common/GltfExport.cs
@@ -15,66 +15,136 @@ using Vector4 = System.Numerics.Vector4;
 using Vector3 = System.Numerics.Vector3;
 using Vector2 = System.Numerics.Vector2;
 using MTex2D = Microsoft.Xna.Framework.Graphics.Texture2D;
+using GaneshaDx.Resources.ContentDataTypes.Palettes;
+using SharpGLTF.Scenes;
 
 namespace GaneshaDx.Common
 {
   public static class GltfExport {
 
-		/**
-		* Exports the map model to the .gltf format.
-		*/
-		public static void Export(string filePath) {
-			var stateTexture = CurrentMapState.StateData.Texture;
-			
-			var greyPalette = new List<Color>() {
-				Utilities.GetColorFromHex("000000"),
-				Utilities.GetColorFromHex("111111"),
-				Utilities.GetColorFromHex("222222"),
-				Utilities.GetColorFromHex("333333"),
-				Utilities.GetColorFromHex("444444"),
-				Utilities.GetColorFromHex("555555"),
-				Utilities.GetColorFromHex("666666"),
-				Utilities.GetColorFromHex("777777"),
-				Utilities.GetColorFromHex("888888"),
-				Utilities.GetColorFromHex("999999"),
-				Utilities.GetColorFromHex("AAAAAA"),
-				Utilities.GetColorFromHex("BBBBBB"),
-				Utilities.GetColorFromHex("CCCCCC"),
-				Utilities.GetColorFromHex("DDDDDD"),
-				Utilities.GetColorFromHex("EEEEEE"),
-				Utilities.GetColorFromHex("FFFFFF")
-			};
-			
-			var texturedMesh = new MeshBuilder<VertexPosition, VertexTexture1>("texturedMesh");
-			var texturedPrims = new List<PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexTexture1, VertexEmpty>>();
-
-			foreach(var palette in CurrentMapState.StateData.Palettes) {
-				var textureColors = new Color[stateTexture.Width * stateTexture.Height];
-				stateTexture.GetData<Color>(textureColors);
-
-				// For the current palette, replace greyscale pixels with palette color.
-				for (int x = 0; x < textureColors.Length; x++) {
-					var pixelColor = textureColors[x];
-					if (greyPalette.Contains(pixelColor)) {
-						var index = greyPalette.IndexOf(pixelColor);
-						var paletteColor = palette.Colors[index];
-						textureColors[x] = paletteColor.ToColor();
-					}
+		private static List<Color> _greyPalette = new List<Color>();
+		public static List<Color> GreyPalette {
+			get {
+				if (_greyPalette.Count > 0) {
+					return _greyPalette;
 				}
 
-				// Convert raw Color data back to a Texture2D to be converted to PNG for embedding.
-				var texture = new MTex2D(Stage.Ganesha.GraphicsDevice, stateTexture.Width, stateTexture.Height);
-				texture.SetData<Color>(textureColors);
-				var stream = new MemoryStream();
-				texture.SaveAsPng(stream, stateTexture.Width, stateTexture.Height);
-				var textureBytes = stream.ToArray();
+				_greyPalette = new List<Color>() {
+					Utilities.GetColorFromHex("000000"),
+					Utilities.GetColorFromHex("111111"),
+					Utilities.GetColorFromHex("222222"),
+					Utilities.GetColorFromHex("333333"),
+					Utilities.GetColorFromHex("444444"),
+					Utilities.GetColorFromHex("555555"),
+					Utilities.GetColorFromHex("666666"),
+					Utilities.GetColorFromHex("777777"),
+					Utilities.GetColorFromHex("888888"),
+					Utilities.GetColorFromHex("999999"),
+					Utilities.GetColorFromHex("AAAAAA"),
+					Utilities.GetColorFromHex("BBBBBB"),
+					Utilities.GetColorFromHex("CCCCCC"),
+					Utilities.GetColorFromHex("DDDDDD"),
+					Utilities.GetColorFromHex("EEEEEE"),
+					Utilities.GetColorFromHex("FFFFFF")
+				};
 
-				var material = new MaterialBuilder();
+				return _greyPalette;
+			}
+		}
+
+		public static void Export(string filePath) {
+			MeshBuilder<VertexPosition, VertexTexture1> texturedMesh = new MeshBuilder<VertexPosition, VertexTexture1>("TexturedMesh");
+			List<PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexTexture1, VertexEmpty>> texturedPrimitives = new List<PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexTexture1, VertexEmpty>>();
+			CreateTextures(texturedPrimitives, texturedMesh);
+
+			MeshBuilder<VertexPosition> blackMesh = new MeshBuilder<VertexPosition>("BlackMesh");
+			MaterialBuilder blackMaterial = new MaterialBuilder();
+			blackMaterial.WithBaseColor(new Vector4(0,0,0,1));
+			PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexEmpty, VertexEmpty> blackPrimitive = blackMesh.UsePrimitive(blackMaterial);
+
+			foreach (Polygon polygon in CurrentMapState.StateData.PolygonCollectionBucket) {
+				if (polygon.IsQuad) {
+					List<Vertex> vertices = polygon.Vertices;
+					List<Microsoft.Xna.Framework.Vector2> uvs = polygon.UvCoordinates;
+
+					if (polygon.IsTextured) {
+						// 0,1,3,2 is FFT vertex order, reversing here to correct facing/back-culling.
+						texturedPrimitives[polygon.PaletteId].AddQuadrangle(
+							(Utilities.ConvertVector3(vertices[2].Position), GetAdjustedUvCoordinates(uvs[2], polygon.TexturePage)),
+							(Utilities.ConvertVector3(vertices[3].Position), GetAdjustedUvCoordinates(uvs[3], polygon.TexturePage)),
+							(Utilities.ConvertVector3(vertices[1].Position), GetAdjustedUvCoordinates(uvs[1], polygon.TexturePage)),
+							(Utilities.ConvertVector3(vertices[0].Position), GetAdjustedUvCoordinates(uvs[0], polygon.TexturePage))
+						);
+					} else {
+						blackPrimitive.AddQuadrangle(
+							ConvertVector3ToVertexPosition(vertices[2].Position), 
+							ConvertVector3ToVertexPosition(vertices[3].Position), 
+							ConvertVector3ToVertexPosition(vertices[1].Position), 
+							ConvertVector3ToVertexPosition(vertices[0].Position)
+						);
+					}
+				} else {
+					List<Vertex> verts = polygon.Vertices;
+					List<Microsoft.Xna.Framework.Vector2> uvs = polygon.UvCoordinates;
+					if (polygon.IsTextured) {
+						texturedPrimitives[polygon.PaletteId].AddTriangle(
+							(Utilities.ConvertVector3(verts[2].Position), GetAdjustedUvCoordinates(uvs[2], polygon.TexturePage)),
+							(Utilities.ConvertVector3(verts[1].Position), GetAdjustedUvCoordinates(uvs[1], polygon.TexturePage)),
+							(Utilities.ConvertVector3(verts[0].Position), GetAdjustedUvCoordinates(uvs[0], polygon.TexturePage))
+						);
+					} else {
+						blackPrimitive.AddTriangle(
+							ConvertVector3ToVertexPosition(verts[2].Position), 
+							ConvertVector3ToVertexPosition(verts[1].Position), 
+							ConvertVector3ToVertexPosition(verts[0].Position)
+						);
+					}
+				}
+			}
+
+			SceneBuilder scene = new SceneBuilder();
+			scene.AddRigidMesh(texturedMesh, Matrix4x4.Identity);
+			scene.AddRigidMesh(blackMesh, Matrix4x4.Identity);
+
+			// @todo: export lights
+
+			ModelRoot model = scene.ToGltf2();
+			WriteSettings settings = new WriteSettings();
+			settings.ImageWriting = ResourceWriteMode.EmbeddedAsBase64;
+			settings.MergeBuffers = true;
+			JsonWriterOptions jsonWriterOptions = new JsonWriterOptions();
+			jsonWriterOptions.Indented = true;
+			settings.JsonOptions = jsonWriterOptions;
+			model.SaveGLTF(filePath, settings);
+		}
+
+		private static VertexPosition ConvertVector3ToVertexPosition (Microsoft.Xna.Framework.Vector3 position) {
+			return new VertexPosition(position.X, position.Y, position.Z);
+		}
+
+		private static Vector2 GetAdjustedUvCoordinates (Microsoft.Xna.Framework.Vector2 uv, int texturePage) {
+			double adjustedX = uv.X / 256f;
+			double adjustedY = (uv.Y + 256 * texturePage) / 1024f;
+			return new Vector2((float) adjustedX, (float) adjustedY);
+		}
+
+		private static void CreateTextures (List<PrimitiveBuilder<MaterialBuilder, VertexPosition, VertexTexture1, VertexEmpty>> texturedPrimitives, MeshBuilder<VertexPosition, VertexTexture1> texturedMesh) {
+			MTex2D stateTexture = CurrentMapState.StateData.Texture;
+
+			foreach(Palette palette in CurrentMapState.StateData.Palettes) {
+				Color[] textureColors = new Color[stateTexture.Width * stateTexture.Height];
+				stateTexture.GetData<Color>(textureColors);
+
+				ApplyPalette(textureColors, palette);
+
+				byte[] textureBytes = GeneratePngBytesFromColors(textureColors);
+
+				MaterialBuilder material = new MaterialBuilder();
 				// @todo: Tweak the material so that it exports as close to possible as game-rendered version.
 				//material.WithMetallicRoughness(0, 0);
 				//material.WithUnlitShader(); // this looks close but material doesn't get lighting at all.
 
-				var memoryImage = new MemoryImage(textureBytes);
+				MemoryImage memoryImage = new MemoryImage(textureBytes);
 
 				// @todo: Why do specular options always crash on export?
 				//material.WithSpecularGlossinessShader()
@@ -91,92 +161,28 @@ namespace GaneshaDx.Common
 									TextureInterpolationFilter.NEAREST
 								);
 
-				texturedPrims.Add(texturedMesh.UsePrimitive(material));
+				texturedPrimitives.Add(texturedMesh.UsePrimitive(material));
 			}
+		}
 
-			var blackMesh = new MeshBuilder<VertexPosition>("blackMesh");
-			var blackMat = new MaterialBuilder();
-			blackMat.WithBaseColor(new Vector4(0,0,0,1));
-			var blackPrim = blackMesh.UsePrimitive(blackMat);
-
-			foreach (Polygon polygon in CurrentMapState.StateData.PolygonCollectionBucket) {
-				if (polygon.IsQuad) {
-					var verts = polygon.Vertices;
-					var uvs = polygon.UvCoordinates;
-
-					if (polygon.IsTextured) {
-						// 0,1,3,2 is FFT vertex order, reversing here to correct facing/back-culling.
-						texturedPrims[polygon.PaletteId].AddQuadrangle(
-							(PositionToV3(verts[2].Position), UvToV2(uvs[2], polygon.TexturePage)),
-							(PositionToV3(verts[3].Position), UvToV2(uvs[3], polygon.TexturePage)),
-							(PositionToV3(verts[1].Position), UvToV2(uvs[1], polygon.TexturePage)),
-							(PositionToV3(verts[0].Position), UvToV2(uvs[0], polygon.TexturePage))
-						);
-					} else {
-						blackPrim.AddQuadrangle(
-							PositionToVPos(verts[2].Position), 
-							PositionToVPos(verts[3].Position), 
-							PositionToVPos(verts[1].Position), 
-							PositionToVPos(verts[0].Position)
-						);
-					}
-				} else {
-					var verts = polygon.Vertices;
-					var uvs = polygon.UvCoordinates;
-					if (polygon.IsTextured) {
-						// 0, 1, 2
-						texturedPrims[polygon.PaletteId].AddTriangle(
-							(PositionToV3(verts[2].Position), UvToV2(uvs[2], polygon.TexturePage)),
-							(PositionToV3(verts[1].Position), UvToV2(uvs[1], polygon.TexturePage)),
-							(PositionToV3(verts[0].Position), UvToV2(uvs[0], polygon.TexturePage))
-						);
-					} else {
-						blackPrim.AddTriangle(
-							PositionToVPos(verts[2].Position), 
-							PositionToVPos(verts[1].Position), 
-							PositionToVPos(verts[0].Position)
-						);
-					}
+		private static void ApplyPalette(Color[] textureColors, Palette palette) {
+			for (int colorIndex = 0; colorIndex < textureColors.Length; colorIndex++) {
+				Color pixelColor = textureColors[colorIndex];
+				if (GreyPalette.Contains(pixelColor)) {
+					int index = GreyPalette.IndexOf(pixelColor);
+					PaletteColor paletteColor = palette.Colors[index];
+					textureColors[colorIndex] = paletteColor.ToColor();
 				}
 			}
-
-			var scene = new SharpGLTF.Scenes.SceneBuilder();
-			scene.AddRigidMesh(texturedMesh, Matrix4x4.Identity);
-			scene.AddRigidMesh(blackMesh, Matrix4x4.Identity);
-
-			// @todo: export lights
-
-			var model = scene.ToGltf2();
-			var settings = new WriteSettings();
-			settings.ImageWriting = ResourceWriteMode.EmbeddedAsBase64;
-			settings.MergeBuffers = true;
-			var jsonWriterOptions = new JsonWriterOptions();
-			jsonWriterOptions.Indented = true;
-			settings.JsonOptions = jsonWriterOptions;
-			model.SaveGLTF(filePath, settings);
 		}
 
-		/**	
-		 * Convert XNA Vector3 to System.Numerics.Vector3.
-		 */ 
-		private static Vector3 PositionToV3 (Microsoft.Xna.Framework.Vector3 position) {
-			return new Vector3(position.X, position.Y, position.Z);
-		}
-
-		/**	
-		 * Convert XNA Vector3 to SharpGLTF VertexPosition.
-		 */ 
-		private static VertexPosition PositionToVPos (Microsoft.Xna.Framework.Vector3 position) {
-			return new VertexPosition(position.X, position.Y, position.Z);
-		}
-
-		/**
-		 * Convert XNA Vector2 to System.Numerics.Vector2 and adjust UV position based on the texture page.
-		 */
-		private static Vector2 UvToV2 (Microsoft.Xna.Framework.Vector2 uv, int texturePage) {
-			double adjustedX = uv.X / 256f;
-			double adjustedY = (uv.Y + 256 * texturePage) / 1024f;
-			return new Vector2((float) adjustedX, (float) adjustedY);
+		private static byte[] GeneratePngBytesFromColors(Color[] textureColors) {
+			MTex2D stateTexture = CurrentMapState.StateData.Texture;
+			MTex2D texture = new MTex2D(Stage.Ganesha.GraphicsDevice, stateTexture.Width, stateTexture.Height);
+			texture.SetData<Color>(textureColors);
+			MemoryStream stream = new MemoryStream();
+			texture.SaveAsPng(stream, stateTexture.Width, stateTexture.Height);
+			return stream.ToArray();
 		}
 	}
 }

--- a/GaneshaDx.csproj
+++ b/GaneshaDx.csproj
@@ -30,5 +30,7 @@
         <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
         <PackageReference Include="Myra" Version="1.2.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="SharpGLTF.Core" Version="1.0.0-alpha0026" />
+        <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0026" />
     </ItemGroup>
 </Project>

--- a/Resources/MapData.cs
+++ b/Resources/MapData.cs
@@ -141,6 +141,11 @@ namespace GaneshaDx.Resources {
 			return true;
 		}
 
+		public static void ExportGltf(string filePath) {
+			GltfExport.Export(filePath);
+			OverlayConsole.AddMessage("Map Exported as " + filePath);
+		}
+
 		public static void ImportTexture(string filePath) {
 			Texture2D importedTexture = Texture2D.FromFile(Stage.GraphicsDevice, filePath);
 

--- a/UserInterface/GuiForms/GuiMenuBar.cs
+++ b/UserInterface/GuiForms/GuiMenuBar.cs
@@ -28,14 +28,6 @@ namespace GaneshaDx.UserInterface.GuiForms {
 
 					ImGui.Separator();
 
-					if (ImGui.MenuItem("Export to GLTF", null, false, MapData.MapIsLoaded)) {
-						string fileName = MapData.MapName + ".gltf";
-
-						MyraGui.OpenExportGltfFileDialog(fileName);
-					}
-
-					ImGui.Separator();
-
 					ImGui.MenuItem("Preferences", "P", ref Gui.ShowPreferencesWindow, MapData.MapIsLoaded);
 
 					ImGui.Separator();
@@ -76,6 +68,14 @@ namespace GaneshaDx.UserInterface.GuiForms {
 
 					if (ImGui.MenuItem("Re-Import Texture", "Ctrl + R", false, canReimportTexture)) {
 						MapData.ImportTexture(MyraGui.LastImportedTextureFile);
+					}
+
+					ImGui.Separator();
+
+					if (ImGui.MenuItem("Export to GLTF", null, false, MapData.MapIsLoaded)) {
+						string fileName = MapData.MapName + ".gltf";
+
+						MyraGui.OpenExportGltfFileDialog(fileName);
 					}
 
 					ImGui.Separator();

--- a/UserInterface/GuiForms/GuiMenuBar.cs
+++ b/UserInterface/GuiForms/GuiMenuBar.cs
@@ -28,6 +28,14 @@ namespace GaneshaDx.UserInterface.GuiForms {
 
 					ImGui.Separator();
 
+					if (ImGui.MenuItem("Export to GLTF", null, false, MapData.MapIsLoaded)) {
+						string fileName = MapData.MapName + ".gltf";
+
+						MyraGui.OpenExportGltfFileDialog(fileName);
+					}
+
+					ImGui.Separator();
+
 					ImGui.MenuItem("Preferences", "P", ref Gui.ShowPreferencesWindow, MapData.MapIsLoaded);
 
 					ImGui.Separator();

--- a/UserInterface/MyraGui.cs
+++ b/UserInterface/MyraGui.cs
@@ -12,6 +12,8 @@ namespace GaneshaDx.UserInterface {
 		public static Desktop Desktop;
 		private static bool _modalIsOpen;
 		private static FileDialog _openFileDialog;
+		private static FileDialog _exportGltfDialog;
+		private static string _lastGltfFileLocation;
 
 		private static FileDialog _importTextureDialog;
 		private static FileDialog _exportTextureDialog;
@@ -30,6 +32,7 @@ namespace GaneshaDx.UserInterface {
 			MyraEnvironment.Game = Stage.Ganesha;
 
 			BuildOpenFileDialog();
+			BuildExportGltfFileDialog();
 
 			BuildImportTextureFileDialog();
 			BuildExportTextureFileDialog();
@@ -63,6 +66,12 @@ namespace GaneshaDx.UserInterface {
 		public static void OpenExportTextureFileDialog(string fileName) {
 			_exportTextureDialog.FilePath = fileName;
 			_exportTextureDialog.ShowModal(Desktop);
+			_modalIsOpen = true;
+		}
+
+		public static void OpenExportGltfFileDialog(string fileName) {
+			_exportGltfDialog.FilePath = fileName;
+			_exportGltfDialog.ShowModal(Desktop);
 			_modalIsOpen = true;
 		}
 
@@ -111,6 +120,33 @@ namespace GaneshaDx.UserInterface {
 					string fileDirectory = string.Join('\\', pathSegments);
 
 					MapData.LoadMapDataFromFiles(fileDirectory, mapName);
+				}
+
+				_modalIsOpen = false;
+			};
+		}
+
+		private static void BuildExportGltfFileDialog() {
+			_exportGltfDialog = new FileDialog(FileDialogMode.SaveFile) {
+				Folder = _lastGltfFileLocation,
+				Filter = "*.gltf"
+			};
+
+			_exportGltfDialog.Closed += (s, a) => {
+				if (_exportGltfDialog.Result) {
+					string filePath = _exportGltfDialog.FilePath;
+					_exportGltfDialog.Folder = filePath;
+					_lastGltfFileLocation = filePath;
+
+					List<string> pathSegments = filePath.Split('\\').ToList();
+					string fileName = pathSegments.Last();
+					List<string> filenameSegments = fileName.Split('.').ToList();
+
+					if (filenameSegments.Last().ToLower() != "gltf") {
+						fileName += ".gltf";
+					}
+
+					MapData.ExportGltf(_exportGltfDialog.Folder + "\\" + fileName);
 				}
 
 				_modalIsOpen = false;


### PR DESCRIPTION
This adds the ability to export the full map polygon, texture, palette, and UV data to the GLTF 2.0 file format. This can be imported into programs such as Blender and Godot or other tools dealing with 3D objects.

For best results when importing to Blender use the import settings:
- "Merge Vertices" checked
- "Shading" = "Use Normal Data"

After import, make sure Blender Viewport Shading is set to:
- Lighting = Flat
- Color = Texture

Known Issues:
- A `.bin` file gets exported with the `.gltf`. It is unknown if this is required or not for importing. I know the `.gltf` contains all the image data, but the `.bin` may contain some polygon data. For now, ensure the `.bin` stays in the same directory as `.gltf`. In the future we can change this to the `.gltf` binary format which is a single file.
- The material shaders are not 100% matching FFT style yet (something to do with specular settings?)
- Textures with transparency (ex: bushes) are missing transparency when using Blender's full render
- No animation frames

Example Export in Blender:
![image](https://user-images.githubusercontent.com/107144620/172706432-87c2335e-cf6f-4dcb-9523-758eaf7f8c88.png)
